### PR TITLE
chore: Update MongoDB connection URL variable name

### DIFF
--- a/lib/database/index.ts
+++ b/lib/database/index.ts
@@ -1,6 +1,6 @@
 import mongoose from "mongoose";
 
-const MONGODB_URL = process.env.MONGODB_URL
+const MONGODB_URI = process.env.MONGODB_URI
 
 let cached = (global as any).mongoose || {conn: null, promise:null}
 
@@ -8,11 +8,11 @@ let cached = (global as any).mongoose || {conn: null, promise:null}
 export const connectToDatabase = async () => {
     if (cached.conn) return cached.conn;
 
-    if (!MONGODB_URL){
+    if (!MONGODB_URI){
         throw new Error("Mongo url missing")
     }
 
-    cached.promise =cached.promise || mongoose.connect(MONGODB_URL, {
+    cached.promise =cached.promise || mongoose.connect(MONGODB_URI, {
         dbName: 'HKongnect',
         bufferCommands: false,
     })


### PR DESCRIPTION
The MongoDB connection URL variable name has been updated from `MONGODB_URL` to `MONGODB_URI` to align with best practices and conventions. This change ensures consistency and clarity in the codebase.